### PR TITLE
Перехват ошибок соединения с БД через Exception

### DIFF
--- a/django_replicated/db_utils.py
+++ b/django_replicated/db_utils.py
@@ -27,7 +27,7 @@ def _db_is_alive(db_name):
             logger.debug(u'Get cursor for db %s.', db_name)
             db.cursor()
         return True
-    except StandardError:
+    except Exception:
         logger.exception(u'Error verifying db %s.', db_name)
         return False
 


### PR DESCRIPTION
DatabaseError, который кидает django наследуется от Exception. StandardError тоже наследуется от Exception, но т.е. нет общего предка, StandardError не может перехватить DatabaseError.
