### PR TITLE
Check database connection in a separate thread and deactivate dead slaves 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *.pyc
+.tox/
+.idea/
+htmlcov/
+.coverage

--- a/django_replicated/__init__.py
+++ b/django_replicated/__init__.py
@@ -1,1 +1,2 @@
 from router import ReplicationRouter
+from failover_router import FailoverReplicationRouter

--- a/django_replicated/db_utils.py
+++ b/django_replicated/db_utils.py
@@ -30,6 +30,7 @@ def _db_is_alive(db_name):
         return True
     except Exception:
         logger.exception(u'Error verifying db %s.', db_name)
+        _close_db_connection(db.connection)
         return False
 
 
@@ -116,3 +117,15 @@ def check_db(
 
 db_is_alive = partial(check_db, _db_is_alive)
 db_is_not_read_only = partial(check_db, _db_is_not_read_only)
+
+
+from .exceptions import DATABASE_ERRORS
+
+def _close_db_connection(connection):
+    if connection:
+        try:
+            connection.close()
+        except DATABASE_ERRORS as exc:
+            # See also https://github.com/celery/django-celery/issues/93
+            if "closed" not in str(exc):
+                raise

--- a/django_replicated/exceptions.py
+++ b/django_replicated/exceptions.py
@@ -1,0 +1,31 @@
+from __future__ import absolute_import
+
+# Database-related exceptions.
+from django.db.utils import DatabaseError
+
+DATABASE_ERRORS = (DatabaseError, )
+
+try:
+    import MySQLdb as mysql
+    DATABASE_ERRORS += (mysql.DatabaseError, )
+except ImportError:
+    pass    # noqa
+
+try:
+    import psycopg2 as pg
+    DATABASE_ERRORS += (pg.DatabaseError, )
+except ImportError:
+    pass      # noqa
+
+try:
+    import sqlite3
+    DATABASE_ERRORS += (sqlite3.DatabaseError, )
+except ImportError:
+    pass    # noqa
+
+try:
+    import cx_Oracle as oracle
+    DATABASE_ERRORS += (oracle.DatabaseError, )
+except ImportError:
+    pass  # noqa
+

--- a/django_replicated/failover_router.py
+++ b/django_replicated/failover_router.py
@@ -1,0 +1,196 @@
+# -*- coding:utf-8 -*-
+import time
+import logging
+import random
+from threading import Thread, RLock, Event
+
+from django.conf import settings
+
+from .router import ReplicationRouter
+from .db_utils import db_is_alive
+
+
+logger = logging.getLogger('replicated.failover_router')
+
+
+class FailoverThread(Thread):
+    def __init__(self, router, check_interval=None, check_master=False):
+        self.router = router
+        self.check_interval = check_interval
+        self.do_check_master = check_master
+        self._stop = Event()
+        Thread.__init__(self)
+
+    def join(self, timeout=None):
+        self._stop.set()
+        Thread.join(self, timeout=timeout)
+
+    def run(self):
+        while not self._stop.isSet():
+            self.check()
+            time.sleep(self.check_interval)
+
+    def check(self):
+        self.check_slaves()
+        if self.do_check_master:
+            self.check_master()
+
+    def check_slaves(self):
+        """
+        Check if slaves alive.
+        Deactivate dead slaves.
+        Activate previously deactivated slaves.
+        """
+        just_dectivated = []
+
+        for alias in self.router.SLAVES:
+            logger.debug('[thread] Check database %s still alive', alias)
+            if not self.db_is_alive(alias):
+                just_dectivated.append(alias)
+                self.router.deactivate_slave(alias)
+
+        for alias in self.router.deactivated_slaves:
+            if alias not in just_dectivated:
+                logger.debug('[thread] Check database %s alive again', alias)
+                if self.db_is_alive(alias):
+                    self.router.activate_slave(alias)
+
+    def check_master(self):
+        """
+        Check master and deactivate it.
+        Deactivated master is a process time economy.
+        """
+
+        alias = self.router.DEFAULT_DB_ALIAS
+        r = self.router
+        if r.master:
+            logger.debug('[thread] Check master %s still alive', alias)
+            if not self.db_is_alive(alias):
+                r.deactivate_master()
+        else:
+            logger.debug('[thread] Check master %s alive again', alias)
+            if self.db_is_alive(alias):
+                r.activate_master()
+
+    def db_is_alive(self, alias, **kwargs):
+        return db_is_alive(alias, **kwargs)
+
+
+class FailoverReplicationRouter(ReplicationRouter):
+    """
+    ReplicationRouter by itself already checks database connection.
+    But on some network failures check may take a long time to finish.
+
+    FailoverReplicationRouter's approach is to check connections
+    in a separate thread and deactivate non-available slaves.
+
+    It reads django settings:
+
+    DATABASE_ASYNC_CHECK bool
+    When False, do not run thread.
+    Default is True
+
+    DATABASE_ASYNC_CHECK_INTERVAL int
+    Seconds to sleep before next check.
+    Default is 5
+
+    DATABASE_CHECK_MASTER bool
+    Experimental feature.
+    If True, thread checks master (default) database connection.
+    When master database connections is dead, db_for_write returns None.
+    Default is False
+    """
+
+    checker_cls = FailoverThread
+
+    def __init__(self, run_thread=None, checker_cls=None):
+        super(FailoverReplicationRouter, self).__init__()
+        self._master = self.DEFAULT_DB_ALIAS
+        self.deactivated_slaves = []
+        self.rlock = RLock()
+        self.thread = None
+        self.checker_cls = checker_cls or self.checker_cls
+
+        if run_thread is None:
+            run_thread = getattr(settings, 'DATABASE_ASYNC_CHECK', True)
+
+        if run_thread:
+            self.thread = self.get_thread()
+            self.thread and self.thread.start()
+
+    def get_thread(self, force=False, check_master=None):
+        if check_master is None:
+            check_master = getattr(settings, 'DATABASE_CHECK_MASTER', False)
+        if force or self.SLAVES or check_master:
+            return self.checker_cls(router=self,
+                                    check_interval=getattr(settings, 'DATABASE_ASYNC_CHECK_INTERVAL', 5),
+                                    check_master=check_master)
+
+    def stop_thread(self):
+        if self.thread:
+            logger.debug("stopping checker thread")
+            self.thread.join(timeout=self.thread.check_interval * 2)
+            logger.debug("checker thread stopped")
+            self.thread = None
+
+    @property
+    def master(self):
+        return self._master
+
+    @master.setter
+    def master(self, alias):
+        self._master = alias
+
+    def deactivate_slave(self, alias):
+        with self.rlock:
+            if alias not in self.deactivated_slaves:
+                self.deactivated_slaves.append(alias)
+            if alias in self.SLAVES:
+                logger.info("Deactivate slave '%s'", alias)
+                self.SLAVES.remove(alias)
+
+    def activate_slave(self, alias):
+        with self.rlock:
+            if alias not in self.SLAVES:
+                logger.info("Activate slave '%s'", alias)
+                self.SLAVES.append(alias)
+            if alias in self.deactivated_slaves:
+                self.deactivated_slaves.remove(alias)
+
+    def deactivate_master(self):
+        with self.rlock:
+            m = self.master
+            if m:
+                logger.info("Deactivate master '%s'", m)
+                self.master = None
+
+    def activate_master(self):
+        with self.rlock:
+            if not self.master:
+                logger.info("Activate master '%s'", self.DEFAULT_DB_ALIAS)
+                self.master = self.DEFAULT_DB_ALIAS
+
+    def db_for_write(self, *a, **kw):
+        master = self.master
+        self.context.chosen['master'] = master
+        return master
+
+    def db_for_read(self, model, **hints):
+        if self.state() == 'master':
+            return self.db_for_write(model, **hints)
+
+        if self.state() in self.context.chosen:
+            r = self.context.chosen[self.state()]
+            if r in self.SLAVES:
+                return r
+
+        if self.SLAVES:
+            chosen = random.choice(self.SLAVES)
+        else:
+            chosen = self.master
+
+        self.context.chosen[self.state()] = chosen
+        return chosen
+
+    def __del__(self):
+        self.stop_thread()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE=tests.test_settings
+django_find_project = false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Django
+pytest
+pytest-django

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# encoding: utf-8

--- a/tests/test_failover_tread.py
+++ b/tests/test_failover_tread.py
@@ -1,0 +1,127 @@
+# encoding: utf-8
+import time
+
+from django_replicated import FailoverReplicationRouter as Router
+from django_replicated.failover_router import FailoverThread
+
+import logging
+logging.basicConfig(level=logging.DEBUG)
+
+def test_thread_cycle():
+    """
+    Check slave selection
+    """
+
+    from django.conf import settings
+
+    settings.DATABASE_SLAVES = ['slave1', 'slave2']
+
+    r = Router(run_thread=False)
+    assert len(r.SLAVES) == 2
+
+    t = r.get_thread(check_master=False)
+
+    # Only slave1 is alive:
+
+    t.db_is_alive = lambda alias: alias == 'slave1'
+    t.check()
+
+    assert r.SLAVES == ['slave1']
+    assert r.deactivated_slaves == ['slave2']
+    assert r.master == r.DEFAULT_DB_ALIAS
+
+    assert r.db_for_write('a') == r.DEFAULT_DB_ALIAS
+    r.use_state('slave')
+    assert r.db_for_read('a') == 'slave1'
+    r.revert()
+
+    # Now only slave2 is alive:
+
+    t.db_is_alive = lambda alias: alias == 'slave2'
+    t.check()
+    assert r.SLAVES == ['slave2']
+    assert r.deactivated_slaves == ['slave1']
+    assert r.master == r.DEFAULT_DB_ALIAS
+    assert r.db_for_write('a') == r.DEFAULT_DB_ALIAS
+    r.use_state('slave')
+    assert r.db_for_read('a') == 'slave2'
+    r.revert()
+
+    # Now only slaves are alive:
+    t.db_is_alive = lambda alias: True
+    t.check()
+    assert sorted(r.SLAVES) == ['slave1', 'slave2']
+    assert r.master == r.DEFAULT_DB_ALIAS
+    assert r.db_for_write('a') == r.DEFAULT_DB_ALIAS
+    r.use_state('slave')
+    assert r.db_for_read('a') in ['slave1', 'slave2']
+    r.revert()
+
+
+def test_thread_cycle_with_master_check():
+    """
+    Check master alive check
+    """
+
+    from django.conf import settings
+
+    settings.DATABASE_SLAVES = ['slave1', 'slave2']
+
+    r = Router(run_thread=False)
+    assert len(r.SLAVES) == 2
+
+    t = FailoverThread(router=r, check_master=True)
+    t.db_is_alive = lambda alias: alias == 'slave1'
+
+    t.check()
+    assert r.master is None
+    assert r.SLAVES == ['slave1']
+    assert r.db_for_write('a') is None
+    r.use_state('slave')
+    assert r.db_for_read('a') == 'slave1'
+    r.revert()
+
+    t.db_is_alive = lambda alias: alias == 'slave2'
+    t.check()
+    assert r.master is None
+    assert r.SLAVES == ['slave2']
+    r.use_state('slave')
+    assert r.db_for_read('a') == 'slave2'
+    r.revert()
+    assert r.db_for_write('a') is None
+
+    t.db_is_alive = lambda alias: alias == r.DEFAULT_DB_ALIAS
+    t.check()
+    assert r.master == r.DEFAULT_DB_ALIAS
+    assert r.SLAVES == []
+    r.use_state('slave')
+    assert r.db_for_read('a') == r.DEFAULT_DB_ALIAS
+    r.revert()
+    assert r.db_for_write('a') == r.DEFAULT_DB_ALIAS
+
+
+def test_thread_run():
+    """
+    Check thread starts and exit
+    """
+    from django.conf import settings
+
+    settings.DATABASE_ASYNC_CHECK = True
+    settings.DATABASE_CHECK_MASTER = True
+    settings.DATABASE_ASYNC_CHECK_INTERVAL = 0.1
+    settings.DATABASE_SLAVES = ['slave1', 'slave2']
+
+    class TestCheckThread(FailoverThread):
+        def db_is_alive(self, alias, **kwargs):
+            return alias == 'slave1'
+
+    class TestRouter(Router):
+        checker_cls = TestCheckThread
+
+    r = TestRouter()
+    time.sleep(r.thread.check_interval * 3)
+    assert r.SLAVES == ['slave1']
+    assert r.deactivated_slaves == ['slave2']
+    assert r.master is None
+
+    r.stop_thread()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,21 @@
+# django settings for tests
+
+SECRET_KEY = '42'
+
+DATABASES = {
+    'default': {
+        'NAME': 'master.sqlite',
+        'ENGINE': 'django.db.backends.sqlite3',
+        },
+    'slave1': {
+        'NAME': 'slave1.sqlite',
+        'ENGINE': 'django.db.backends.sqlite3',
+        },
+    'slave2': {
+        'NAME': 'slave2.sqlite',
+        'ENGINE': 'django.db.backends.sqlite3',
+        },
+
+    }
+
+DATABASE_SLAVES = ['slave1', 'slave2']

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+envlist = py27
+
+[testenv]
+setenv =
+	PYTHONPATH=.:$PYTHONPATH
+	DJANGO_SETTINGS_MODULE=tests.test_settings
+commands = py.test --cov-report term --cov-report html --cov django_replicated {posargs}
+deps =
+	pytest
+	pytest-cov
+	pytest-django
+	Django==1.6
+
+


### PR DESCRIPTION
ReplicationRouter already checks database connection.
But on some network failures check may take a long time to finish.

FailoverReplicationRouter's approach is to check slave connection in separate thread and deactivate nonavailable slaves.
