### PR TITLE
Replace deprecated get_caches in favour of caches

### DIFF
--- a/django_replicated/db_utils.py
+++ b/django_replicated/db_utils.py
@@ -5,14 +5,14 @@ from datetime import datetime, timedelta
 from functools import partial
 
 from django.conf import settings
-from django.core.cache import get_cache, DEFAULT_CACHE_ALIAS
+from django.core.cache import caches, DEFAULT_CACHE_ALIAS
 
 
 logger = logging.getLogger('replicated.db_checker')
 
-cache = get_cache(
+cache = caches[
     getattr(settings, 'REPLICATED_CACHE_BACKEND', DEFAULT_CACHE_ALIAS)
-)
+]
 host_name = socket.gethostname()
 
 


### PR DESCRIPTION
In Django 1.7 django.core.cache.get_cache has been supplanted by django.core.cache.caches
https://docs.djangoproject.com/en/dev/releases/1.7/#django-core-cache-get-cache