### PR TITLE
Allow master-master replication schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,12 @@ SQL operations.
 
         REPLICATED_DATABASE_SLAVES = ['slave1', 'slave2']
 
-    The 'default' database is always treated as master.
+    The 'default' database is by default treated as master.
+
+    OPTIONALLY, you can teach which databases are the masters, for master-master
+    replication scenarios:
+
+        REPLICATED_DATABASE_MASTERS = ['default', 'master2']
 
 1.  Configure a replication router:
 

--- a/django_replicated/router.py
+++ b/django_replicated/router.py
@@ -106,10 +106,13 @@ class ReplicationRouter(object):
 
         slaves = self.SLAVES[:]
         random.shuffle(slaves)
+        masters = self.MASTERS[:]
+        random.shuffle(masters)
 
-        for slave in slaves:
-            if self.is_alive(slave):
-                chosen = slave
+        # Try masters if slaves cannot be used
+        for db in slaves + masters:
+            if self.is_alive(db):
+                chosen = db
                 break
         else:
             chosen = self.DEFAULT_DB_ALIAS

--- a/django_replicated/router.py
+++ b/django_replicated/router.py
@@ -28,7 +28,21 @@ class ReplicationRouter(object):
         self._context.inited = True
 
     def _get_actual_master(self):
-        return self.MASTERS[0]  # DEFAULT_DB_ALIAS
+        try:
+            chosen = self._context.actual_master
+            if not self.is_alive(chosen):
+                raise RuntimeError()
+        except (AttributeError, RuntimeError):
+            # Be predictable here. No shuffle for master
+            for db in self.MASTERS:
+                if self.is_alive(db):
+                    chosen = db
+                    break
+            else:
+                chosen = self.DEFAULT_DB_ALIAS
+
+            self.context.actual_master = chosen
+        return chosen
 
     @property
     def context(self):

--- a/django_replicated/router.py
+++ b/django_replicated/router.py
@@ -15,16 +15,20 @@ class ReplicationRouter(object):
 
         self.DEFAULT_DB_ALIAS = DEFAULT_DB_ALIAS
         self.DOWNTIME = settings.REPLICATED_DATABASE_DOWNTIME
+        self.MASTERS = settings.REPLICATED_DATABASE_MASTERS or [DEFAULT_DB_ALIAS]
         self.SLAVES = settings.REPLICATED_DATABASE_SLAVES or [DEFAULT_DB_ALIAS]
         self.CHECK_STATE_ON_WRITE = settings.REPLICATED_CHECK_STATE_ON_WRITE
 
-        self.all_allowed_aliases = [self.DEFAULT_DB_ALIAS] + self.SLAVES
+        self.all_allowed_aliases = self.MASTERS + self.SLAVES
 
     def _init_context(self):
         self._context.state_stack = []
         self._context.chosen = {}
         self._context.state_change_enabled = True
         self._context.inited = True
+
+    def _get_actual_master(self):
+        return self.MASTERS[0]  # DEFAULT_DB_ALIAS
 
     @property
     def context(self):
@@ -74,9 +78,10 @@ class ReplicationRouter(object):
         if self.CHECK_STATE_ON_WRITE and self.state() != 'master':
             raise RuntimeError('Trying to access master database in slave state')
 
-        self.context.chosen['master'] = self.DEFAULT_DB_ALIAS
+        actual_master = self._get_actual_master()
+        self.context.chosen['master'] = actual_master
 
-        return self.DEFAULT_DB_ALIAS
+        return actual_master
 
     def db_for_read(self, model, **hints):
         if self.state() == 'master':

--- a/django_replicated/settings.py
+++ b/django_replicated/settings.py
@@ -7,6 +7,9 @@ REPLICATED_DATABASE_DOWNTIME = 60
 # List of slave database aliases. Default database is always master
 REPLICATED_DATABASE_SLAVES = []
 
+# List of master database aliases. Default is to only be the 'default' database
+REPLICATED_DATABASE_MASTERS = []
+
 # View name to state mapping
 REPLICATED_VIEWS_OVERRIDES = {}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ pytestmark = pytest.mark.django_db
 def pytest_configure():
     settings.configure(**dict(replicated_settings.__dict__,
         DATABASES={'default': {'ENGINE': 'django.db.backends.sqlite3'},
+                   'master2': {'ENGINE': 'django.db.backends.sqlite3'},
                    'slave1': {'ENGINE': 'django.db.backends.sqlite3'},
                    'slave2': {'ENGINE': 'django.db.backends.sqlite3'},},
         REPLICATED_DATABASE_SLAVES=['slave1', 'slave2'],


### PR DESCRIPTION
Setting the new ``REPLICATED_DATABASE_MASTERS`` option, one can use master-master replication schemes, for e.g. the MySQL circular replication scheme, Postgres-BDR or MySQL NDB Cluster.