### PR TITLE
django_replicated should reset the router state after request has been processed

### DIFF
--- a/django_replicated/dbchecker.py
+++ b/django_replicated/dbchecker.py
@@ -7,15 +7,14 @@ from functools import partial
 
 from django.conf import settings
 from django.core.cache import DEFAULT_CACHE_ALIAS
-from django.utils import timezone
 from django.db import connections
 
 try:
     from django.core.cache import get_cache
-except ImportError: # Django >= 1.7
+except ImportError:  # Django >= 1.7
     from django.core.cache import caches
 
-    get_cache = lambda alias: caches[alias]
+    def get_cache(alias): return caches[alias]
 
 
 from .utils import get_object_name

--- a/django_replicated/middleware.py
+++ b/django_replicated/middleware.py
@@ -43,6 +43,7 @@ class ReplicationMiddleware(object):
         routers.init(state)
 
     def process_response(self, request, response):
+        routers.reset()
         self.handle_redirect_after_write(request, response)
         return response
 

--- a/django_replicated/router.py
+++ b/django_replicated/router.py
@@ -20,7 +20,7 @@ class ReplicationRouter(object):
 
         self.all_allowed_aliases = [self.DEFAULT_DB_ALIAS] + self.SLAVES
 
-    def _init_context(self):
+    def reset(self):
         self._context.state_stack = []
         self._context.chosen = {}
         self._context.state_change_enabled = True
@@ -29,11 +29,11 @@ class ReplicationRouter(object):
     @property
     def context(self):
         if not getattr(self._context, 'inited', False):
-            self._init_context()
+            self.reset()
         return self._context
 
     def init(self, state):
-        self._init_context()
+        self.reset()
         self.use_state(state)
 
     def is_alive(self, db_name):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/tests/_test_urls.py
+++ b/tests/_test_urls.py
@@ -4,10 +4,13 @@ from __future__ import unicode_literals
 from django.conf.urls import url
 from django.http import HttpResponseRedirect, HttpResponse
 from django.views.generic import View
+from django_replicated.utils import routers
 
 
 def view(request):
-    return HttpResponseRedirect('/')
+    response = HttpResponseRedirect('/')
+    response['Router-Used'] = routers.state()
+    return response
 
 
 def just_updated_view(request):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,22 +1,26 @@
 # coding: utf-8
+from __future__ import unicode_literals
 
 import pytest
-
 from django.conf import settings
 
 from django_replicated import settings as replicated_settings
-
 
 pytestmark = pytest.mark.django_db
 
 
 def pytest_configure():
-    settings.configure(**dict(replicated_settings.__dict__,
-        DATABASES={'default': {'ENGINE': 'django.db.backends.sqlite3'},
-                   'slave1': {'ENGINE': 'django.db.backends.sqlite3'},
-                   'slave2': {'ENGINE': 'django.db.backends.sqlite3'},},
-        REPLICATED_DATABASE_SLAVES=['slave1', 'slave2'],
-        DATABASE_ROUTERS=['django_replicated.router.ReplicationRouter'],
-        MIDDLEWARE_CLASSES=['django_replicated.middleware.ReplicationMiddleware'],
-        ROOT_URLCONF='tests._test_urls',
-    ))
+    test_settings = replicated_settings.__dict__.copy()
+    test_settings.update({
+        'DATABASES': {
+            'default': {'ENGINE': 'django.db.backends.sqlite3'},
+            'slave1': {'ENGINE': 'django.db.backends.sqlite3'},
+            'slave2': {'ENGINE': 'django.db.backends.sqlite3'}, },
+        'REPLICATED_DATABASE_SLAVES': ['slave1', 'slave2'],
+        'DATABASE_ROUTERS': ['django_replicated.router.ReplicationRouter'],
+        'MIDDLEWARE_CLASSES': [
+            'django_replicated.middleware.ReplicationMiddleware'],
+        'ROOT_URLCONF': 'tests._test_urls',
+    })
+
+    settings.configure(**test_settings)

--- a/tests/test_dbchecker.py
+++ b/tests/test_dbchecker.py
@@ -9,11 +9,11 @@ from django_replicated.dbchecker import cache, check_db, hostname
 
 
 def test_check_success():
-    assert check_db(MagicMock(return_value=True), 'default') == True
+    assert check_db(MagicMock(return_value=True), 'default') is True
 
 
 def test_check_fail():
-    assert check_db(MagicMock(return_value=False), 'default') == False
+    assert check_db(MagicMock(return_value=False), 'default') is False
 
 
 def test_check_retry():


### PR DESCRIPTION
Currently django_replicated does not clean up the router's state after request has been processed. This is not a big issue, because it will do so on the next request, but it still has some drawbacks. For example, in the test case one could use django's TestClient to get the result of some view, and then write something in the database in the same test case. django_replicated currently prevents that, setting thread-local state of routers to the 'slave' state for GET/HEAD requests.
This pull request renames _init_context() to the reset(), making it public API, and calls this method in the process_response method of the middleware.