### PR TITLE
No using deprecated get_cache since django 1.7

### DIFF
--- a/django_replicated/dbchecker.py
+++ b/django_replicated/dbchecker.py
@@ -5,15 +5,16 @@ import logging
 import socket
 from functools import partial
 
+import django
 from django.conf import settings
 from django.core.cache import DEFAULT_CACHE_ALIAS
 from django.db import connections
 
-try:
+if django.get_version() < '1.7':
+    # https://docs.djangoproject.com/en/1.7/topics/cache/#django.core.cache.get_cache
     from django.core.cache import get_cache
-except ImportError:  # Django >= 1.7
+else:
     from django.core.cache import caches
-
     def get_cache(alias): return caches[alias]
 
 


### PR DESCRIPTION
With this check apps with django 1.7 & 1.8 will not have gazillion of warnings like
```
.../python2.7/site-packages/django_replicated/dbchecker.py:26: RemovedInDjango19Warning: 
'get_cache' is deprecated in favor of 'caches'.
  cache = get_cache(settings.REPLICATED_CACHE_BACKEND or DEFAULT_CACHE_ALIAS)
```