### PR TITLE
Do not reset routers state before handle_redirect_after_write: it use…

### DIFF
--- a/django_replicated/middleware.py
+++ b/django_replicated/middleware.py
@@ -65,8 +65,8 @@ class ReplicationMiddleware(object):
             self.set_non_atomic_dbs(view)
 
     def process_response(self, request, response):
-        routers.reset()
         self.handle_redirect_after_write(request, response)
+        routers.reset()
         return response
 
     def check_state_override(self, request, state):

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -38,6 +38,11 @@ def test_replicated_middleware_master_state(client):
     assert client.cookies[settings.REPLICATED_FORCE_MASTER_COOKIE_NAME].value == 'true'
 
 
+def test_does_not_set_force_master_cookie_on_get(client):
+    client.get('/')
+    assert client.cookies == {}
+
+
 @pytest.mark.parametrize('url,view_id', [('/', 'tests._test_urls.view'),
                                          ('/with_name', 'view-name'),
                                          ('/as_class', 'tests._test_urls.TestView'),


### PR DESCRIPTION
…d routers state and set cookie on GET requests