### PR TITLE
Debug logs

### DIFF
--- a/django_replicated/dbchecker.py
+++ b/django_replicated/dbchecker.py
@@ -77,14 +77,14 @@ def check_db(checker, db_name, cache_seconds=None, number_of_tries=1, force=Fals
 
         if is_dead:
             log.debug(
-                'Last check "%s" %s was less than %d ago, no check needed',
+                'Check "%s" %s was failed less than %d ago, no check needed',
                 checker_name, db_name, cache_seconds
             )
 
             return False
         else:
             log.debug(
-                'Last check "%s" %s was more than %d ago, checking again',
+                'Last check "%s" %s succeeded or was more than %d ago, checking again',
                 db_name, checker_name, cache_seconds
             )
     else:

--- a/django_replicated/router.py
+++ b/django_replicated/router.py
@@ -1,8 +1,11 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
+import logging
 import random
 from threading import local
+
+log = logging.getLogger(__name__)
 
 
 class ReplicationRouter(object):
@@ -76,6 +79,7 @@ class ReplicationRouter(object):
 
         self.context.chosen['master'] = self.DEFAULT_DB_ALIAS
 
+        log.debug('db_for_write: %s', self.DEFAULT_DB_ALIAS)
         return self.DEFAULT_DB_ALIAS
 
     def db_for_read(self, *args, **kwargs):
@@ -97,6 +101,7 @@ class ReplicationRouter(object):
 
         self.context.chosen[self.state()] = chosen
 
+        log.debug('db_for_read: %s', chosen)
         return chosen
 
     def allow_relation(self, obj1, obj2, **hints):


### PR DESCRIPTION
In first commit i fixed confusing logs in `dbchecker.py`, because in normal mode, when everything works we get
`Last check "slave" is_alive was more than 60 ago, checking again`
which is confusing, because last check was at previous request moments ago.

In second commit i added more debug logs in some places. I guess nobody will be affected by it, but they are helpful while debugging application and databases interaction. For example one can see what database is using for read and write and why state was chosen.