### PR TITLE
Correct version comparation

### DIFF
--- a/django_replicated/dbchecker.py
+++ b/django_replicated/dbchecker.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.core.cache import DEFAULT_CACHE_ALIAS
 from django.db import connections
 
-if django.get_version() < '1.7':
+if django.VERSION < (1, 7):
     # https://docs.djangoproject.com/en/1.7/topics/cache/#django.core.cache.get_cache
     from django.core.cache import get_cache
 else:


### PR DESCRIPTION
Since version '1.10' comparision broken, so i guess django.VERSION tuple is the only correct way
```
>>> django.VERSION
... Out[7]: (1, 10, 8, u'final', 0)
```

BTW tests found that, but i ran them while working on another PR, so it was too late. We should set travis for repo.