### PR TITLE
Missed Django==1.7 for tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27}-{django16,django18,django19,django110,django111},{py35}-{django18,django19,django110,django111},{pypy}-{django18,django19,django110,django111}
+envlist = {py27}-{django16,django17,django18,django19,django110,django111},{py35}-{django18,django19,django110,django111},{pypy}-{django18,django19,django110,django111}
 skipsdist = {env:TOXBUILD:false}
 
 [testenv]
@@ -10,6 +10,7 @@ deps=
     mock==1.3.0
 
     django16: Django>=1.6,<1.7
+    django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11


### PR DESCRIPTION
I guess it was mistakenly missed, not on purpose.