### PR TITLE
fix state-changing decorators

### DIFF
--- a/django_replicated/decorators.py
+++ b/django_replicated/decorators.py
@@ -25,5 +25,5 @@ from .middleware import ReplicationMiddleware
 
 
 use_state = decorator_from_middleware_with_args(ReplicationMiddleware)
-use_master = use_state('master')
-use_slave = use_state('slave')
+use_master = use_state(forced_state='master')
+use_slave = use_state(forced_state='slave')


### PR DESCRIPTION
State changing decorators passed `forced_state` argument as a first positional argument, but it must be the second one