### PR TITLE
`set_non_atomic_dbs` fails to set attributes on instacemethods

### DIFF
--- a/django_replicated/middleware.py
+++ b/django_replicated/middleware.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import inspect
 import logging
 import fnmatch
+import types
 from functools import partial
 
 from django import db
@@ -66,6 +67,9 @@ class ReplicationMiddleware(MiddlewareMixin):
         routers.init(state)
 
     def set_non_atomic_dbs(self, view):
+        if isinstance(view, types.MethodType):
+            view = six.get_method_function(view)
+
         default_attr = '_replicated_view_default_non_atomic_dbs'
         default_set = getattr(view, default_attr, None)
         # If default_set is None then this first request. Set default.

--- a/tests/_test_urls.py
+++ b/tests/_test_urls.py
@@ -33,7 +33,6 @@ def just_updated_view(request):
 class TestView(View):
     def get(self, request):
         response = get_response()
-        set_non_atomic_attributes(response, self.get)
         return response
 
 

--- a/tests/_test_urls.py
+++ b/tests/_test_urls.py
@@ -21,12 +21,20 @@ def just_updated_view(request):
 
 class TestView(View):
     def get(self, request):
-        return HttpResponseRedirect('/')
+        return view(request)
 
 
 class TestCallable(object):
     def __call__(self, request):
-        return HttpResponseRedirect('/')
+        return view(request)
+
+
+class TestInstanceMethod(object):
+    def instancemethodview(self, request):
+        return view(request)
+
+
+instance_view = TestInstanceMethod()
 
 
 @transaction.non_atomic_requests
@@ -43,5 +51,6 @@ urlpatterns = [
     url(r'^with_name$', view, name='view-name'),
     url(r'^as_class$', TestView.as_view()),
     url(r'^as_callable$', TestCallable()),
+    url(r'^as_instancemethod$', instance_view.instancemethodview),
     url(r'^non_atomic_view$', non_atomic_view),
 ]

--- a/tests/_test_urls.py
+++ b/tests/_test_urls.py
@@ -40,7 +40,7 @@ class TestView(View):
 class TestCallable(object):
     def __call__(self, request):
         response = get_response()
-        set_non_atomic_attributes(response, self.__call__)
+        set_non_atomic_attributes(response, self)
         return response
 
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -48,7 +48,8 @@ def test_does_not_set_force_master_cookie_on_get(client):
                                          ('/admin/auth/', '/admin/*'),
                                          ('/with_name', 'view-name'),
                                          ('/as_class', 'tests._test_urls.TestView'),
-                                         ('/as_callable', 'tests._test_urls.TestCallable')])
+                                         ('/as_callable', 'tests._test_urls.TestCallable'),
+                                         ('/as_instancemethod', 'tests._test_urls.instancemethodview')])
 def test_replicated_middleware_view_overrides(client, settings, url, view_id):
     routers.init('slave')
 
@@ -57,6 +58,7 @@ def test_replicated_middleware_view_overrides(client, settings, url, view_id):
     response = client.get(url)
 
     assert response.status_code == 302
+    assert response['Router-Used'] == 'master'
     assert routers.state() == 'master'
 
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -152,7 +152,7 @@ def test_non_atomic_view(client):
             assert view._non_atomic_requests == {'default', 'slave1', 'slave2'} - {response['DB-Used']}
 
 
-@pytest.mark.parametrize('url', ['/', '/with_name', '/as_class', '/as_callable', '/as_instancemethod'])
+@pytest.mark.parametrize('url', ['/', '/with_name', '/as_callable', '/as_instancemethod'])
 def test_atomic_view(client, url):
     with override_settings(REPLICATED_MANAGE_ATOMIC_REQUESTS=True):
         with patch('django.db.transaction.atomic') as atomic:


### PR DESCRIPTION
In Django, a view can be a bound method of some class: what is callable is fine to be a view. With `REPLICATED_MANAGE_ATOMIC_REQUESTS` set to `True`, `set_non_atomic_dbs` attempts to set attributes on a view, but `instancemethod`s are special things: you could not set an attribute for the `instancemethod`. There are even bound-method-views that are built-in, for example, it's login view of Django's `contrib.admin`. I have attached failing tests to demonstate the issue.