### PR TITLE
Add ReplicationMiddleware.process_exception

### DIFF
--- a/django_replicated/middleware.py
+++ b/django_replicated/middleware.py
@@ -96,6 +96,10 @@ class ReplicationMiddleware(MiddlewareMixin):
         routers.reset()
         return response
 
+    def process_exception(self, request, exception):
+        if settings.REPLICATED_RESET_ON_EXCEPTION:
+            routers.reset()
+
     def check_state_override(self, request, state):
         '''
         Used to check if a web request should use a master or slave

--- a/django_replicated/settings.py
+++ b/django_replicated/settings.py
@@ -31,5 +31,8 @@ REPLICATED_CHECK_STATE_ON_WRITE = True
 # Status codes on which set cookie for read-after-write workaround
 REPLICATED_FORCE_MASTER_COOKIE_STATUS_CODES = (302, 303)
 
+# Reset state on exception in request
+REPLICATED_RESET_ON_EXCEPTION = False
+
 
 REPLICATED_MANAGE_ATOMIC_REQUESTS = False


### PR DESCRIPTION
When you wrap a view with decorator (like this `@method_decorator(use_slave, name='dispatch')`), and than catch any exception inside it `routers.reset()` does not call and your base stays in the slave state. 
This PR allows you to call `reset()` anyway