### PR TITLE
Replace log.exception with debug, it spams log when slave is dead

### DIFF
--- a/django_replicated/dbchecker.py
+++ b/django_replicated/dbchecker.py
@@ -101,7 +101,7 @@ def check_db(checker, db_name, cache_seconds=None, number_of_tries=1, force=Fals
             result = checker(connection)
         except Exception:
             if count == number_of_tries:
-                log.exception('Error verifying %s: %s', checker_name, db_name)
+                log.warning('Error verifying %s: %s', checker_name, db_name)
 
             result = False
 


### PR DESCRIPTION
Without tests, cant build against latest tox image fails

`pypy-django18 create: /app/.tox/pypy-django18
ERROR: invocation failed (exit code 1), logfile: /app/.tox/pypy-django18/log/pypy-django18-0.log
ERROR: actionid: pypy-django18
msg: getenv
cmdargs: ['/.pyenv/versions/3.7.0/bin/python', '-m', 'virtualenv', '--python', '/.pyenv/shims/pypy', 'pypy-django18']

Using base prefix '/.pyenv/versions/pypy3.3-5.5-alpha'
New pypy executable in /app/.tox/pypy-django18/bin/pypy
Installing setuptools, pip, wheel...
  Complete output from command /app/.tox/pypy-django18/bin/pypy - setuptools pip wheel:
  DEPRECATION: Python 3.3 supported has been deprecated and support for it will be dropped in the future. Please upgrade your Python.
Looking in links: /.pyenv/versions/3.7.0/lib/python3.7/site-packages, /.pyenv/versions/3.7.0/lib/python3.7/site-packages/virtualenv_support
Collecting setuptools
  Using cached https://files.pythonhosted.org/packages/7f/e1/820d941153923aac1d49d7fc37e17b6e73bfbd2904959fffbad77900cf92/setuptools-39.2.0-py2.py3-none-any.whl
Collecting pip
Collecting wheel
wheel requires Python '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*' but the running Python is 3.3.5
----------------------------------------
...Installing setuptools, pip, wheel...done.
Traceback (most recent call last):
  File "/.pyenv/versions/3.7.0/lib/python3.7/site-packages/virtualenv.py", line 2343, in <module>
    main()
  File "/.pyenv/versions/3.7.0/lib/python3.7/site-packages/virtualenv.py", line 712, in main
    symlink=options.symlink)
  File "/.pyenv/versions/3.7.0/lib/python3.7/site-packages/virtualenv.py", line 947, in create_environment
    download=download,
  File "/.pyenv/versions/3.7.0/lib/python3.7/site-packages/virtualenv.py", line 904, in install_wheel
    call_subprocess(cmd, show_stdout=False, extra_env=env, stdin=SCRIPT)
  File "/.pyenv/versions/3.7.0/lib/python3.7/site-packages/virtualenv.py", line 796, in call_subprocess
    % (cmd_desc, proc.returncode))
OSError: Command /app/.tox/pypy-django18/bin/pypy - setuptools pip wheel failed with error code 1
Running virtualenv with interpreter /.pyenv/shims/pypy

ERROR: Error creating virtualenv. Note that some special characters (e.g. ':' and unicode symbols) in paths are not supported by virtualenv. Error details: InvocationError('/.pyenv/versions/3.7.0/bin/python -m virtualenv --python /.pyenv/shims/pypy pypy-django18 (see /app/.tox/pypy-django18/log/pypy-django18-0.log)', 1)`