### PR TITLE
fix compatability with django 3.0 removal of django.utils.six

### DIFF
--- a/django_replicated/middleware.py
+++ b/django_replicated/middleware.py
@@ -6,10 +6,11 @@ import logging
 import fnmatch
 import types
 from functools import partial
+import six
 
 from django import db
 from django.conf import settings
-from django.utils import six, functional
+from django.utils import functional
 
 try:  # django 1.10+
     from django import urls

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,6 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
-    ]
+    ],
+    install_requires=['six']
 )


### PR DESCRIPTION
Django 3.0 has removed six from `django.utils` (https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis). In order to be django 3.0 compatible, this PR switches to `six` from pypi as recommended in the release notes, and adds `six` as an `install_requires` in `setup.py`