### PR TITLE
Check if database is really alive

### DIFF
--- a/django_replicated/dbchecker.py
+++ b/django_replicated/dbchecker.py
@@ -40,8 +40,8 @@ def is_alive(connection):
             connection.connection.ping()
     else:
         log.debug('Get cursor for db: %s', connection.alias)
-        with connection.cursor():
-            pass
+        with connection.cursor() as cur:
+            cur.execute("SELECT 1")
 
     return True
 


### PR DESCRIPTION
Adding a check for postgresql to avoid the loss of a request.

The connection.cursor() opens a connection for CONN_MAX_AGE time if it is not already open.
Otherwise, the old cursor is used and no verification is done.

This is inspired by the is_usable() method of django.
https://github.com/django/django/blob/76c0b32f826469320c59709d31e2f2126dd7c505/django/db/backends/postgresql/base.py#L298